### PR TITLE
Switch away from deprecated setup-android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,7 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Build with Gradle
-        uses: msfjarvis/setup-android@1.0
-        with:
-          entrypoint: ./gradlew
-          args: build
+        run: ./gradlew build


### PR DESCRIPTION
I am in the process of deprecating setup-android as GitHub Actions now ships default containers with everything that's needed.
﻿